### PR TITLE
SFW-148: Update README, LICENSE & podspec to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,21 @@
-Copyright (c) 2018 stanwood GmbH
+The MIT License (MIT)
+
+Copyright ©️ 2018 stanwood GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -61,4 +61,4 @@ Check out the [full documentations](https://stanwood.github.io/Stanwood_Core).
 
 ## Licence
 
-StanwoodCore is a private library. See the [LICENSE](https://github.com/stanwood/Stanwood_Core/blob/master/LICENSE) file for more info.
+StanwoodCore is is under MIT licence. See the [LICENSE](https://github.com/stanwood/Stanwood_Core/blob/master/LICENSE) file for more info.

--- a/StanwoodCore.podspec
+++ b/StanwoodCore.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'StanwoodCore'
-    s.version          = '0.3.0'
+    s.version          = '0.3.1'
     s.summary          = 'Stanwood core libarary'
     
     s.description      = <<-DESC
@@ -16,9 +16,9 @@ Pod::Spec.new do |s|
     DESC
     
     s.homepage         = 'https://github.com/stanwood/Stanwood_Core'
-    s.license          = { :type => 'Private', :file => 'LICENSE' }
+    s.license          = { :type => 'MIT', :file => 'LICENSE' }
     s.author           = { 'Tal Zion' => 'talezion@gmail.com' }
-    s.source           = { :git => 'git@github.com:stanwood/Stanwood_Core.git', :tag => s.version.to_s }
+    s.source           = { :git => 'https://github.com/stanwood/Stanwood_Core.git', :tag => s.version.to_s }
     
     s.ios.deployment_target = '10.0'
     


### PR DESCRIPTION
## WIP

## Description

Ticket: [SFW-148](https://stanwood.atlassian.net/browse/SFW-148)

✅ Update licence in .podspec to MIT
✅ Update README licence to MIT
✅ Update LICENCE file to MIT
✅ Set s.source to HTTP, instead of ssh
✅ Update Usage(Installation guide)
❌ Replace the headers in all source files. and include copyright and MIT licence
✅ Replace the string in the Example launch screen to state copyright Stanwood GmbH.
❌ Check spelling of class and folder names.
❌ Cleanup the Podspec file and ensure that it has both a meaningful summary and description.
✅ Ensure the the Podfile in the example project has "platform :ios, 10".
✅ Version bump 
❌ push to master repo